### PR TITLE
fix: pin unstable nixpkgs to latest stable release (18.09)

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -27,8 +27,8 @@ RUN echo ". ${ENV}" >> ${HOME}/.profile
 # All subsequent "RUN" will use a login shell
 SHELL ["/usr/bin/env", "bash", "-l", "-c"]
 
-RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable \
-    && nix-channel --update
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-18.09-darwin nixpkgs \
+  && nix-channel --update
 
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -27,8 +27,8 @@ RUN echo ". ${ENV}" >> ${HOME}/.profile
 # All subsequent "RUN" will use a login shell
 SHELL ["/usr/bin/env", "bash", "-l", "-c"]
 
-RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable \
-    && nix-channel --update
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-18.09-darwin nixpkgs \
+  && nix-channel --update
 
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553


### PR DESCRIPTION
We currently use the `unstable` nixpkgs channel. 
This PR fixes this by pinning it to the latest release `18.09`.