### PR TITLE
Upgrade from 18.09 to 19.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This image contains an installation of the [Nix package manager](https://nixos.org/nix/) installed as a single-user `nixuser`.
 
-This is based on the unpublished Dockerfile of https://github.com/romcheck/nix.
+This is based on the unpublished Dockerfile previously available at https://github.com/romcheck/nix.
 
 Use this build to create your own customized images as follows:
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -27,8 +27,9 @@ RUN echo ". ${ENV}" >> ${HOME}/.profile
 # All subsequent "RUN" will use a login shell
 SHELL ["/usr/bin/env", "bash", "-l", "-c"]
 
-RUN nix-channel --add https://nixos.org/channels/nixpkgs-18.09-darwin nixpkgs \
-  && nix-channel --update
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.03-darwin nixpkgs \
+    && nix-channel --add https://nixos.org/channels/nixpkgs-unstable unstable \
+    && nix-channel --update
 
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine
 
 ARG NIX_VERSION
-ENV NIX_VERSION ${NIX_VERSION:-2.1.3}
+ENV NIX_VERSION ${NIX_VERSION:-2.2.1}
 ARG LANG
 ENV LANG ${LANG:-"en_US.UTF-8"}
 
@@ -11,7 +11,9 @@ RUN addgroup -g 30000 -S nixbld \
     && adduser -D nixuser \
     && mkdir -m 0755 /nix && chown nixuser /nix \
     && apk add --no-cache bash \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    # sandboxing enabled by default since 2.2
+    && mkdir -p /etc/nix && echo 'sandbox = false' > /etc/nix/nix.conf
 
 USER nixuser
 ENV USER=nixuser

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:stable-slim
 
 ARG NIX_VERSION
-ENV NIX_VERSION ${NIX_VERSION:-2.1.3}
+ENV NIX_VERSION ${NIX_VERSION:-2.2.1}
 ARG LANG
 ENV LANG ${LANG:-"en_US.UTF-8"}
 
@@ -11,7 +11,9 @@ RUN addgroup --gid 30000 --system nixbld \
     && adduser --disabled-password nixuser \
     && mkdir -m 0755 /nix && chown nixuser /nix \
     && apt update && apt install -y wget bzip2 \
-    && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    # sandboxing enabled by default since 2.2
+    && mkdir -p /etc/nix && echo 'sandbox = false' > /etc/nix/nix.conf
 
 USER nixuser
 ENV USER=nixuser

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -27,8 +27,9 @@ RUN echo ". ${ENV}" >> ${HOME}/.profile
 # All subsequent "RUN" will use a login shell
 SHELL ["/usr/bin/env", "bash", "-l", "-c"]
 
-RUN nix-channel --add https://nixos.org/channels/nixpkgs-18.09-darwin nixpkgs \
-  && nix-channel --update
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.03-darwin nixpkgs \
+    && nix-channel --add https://nixos.org/channels/nixpkgs-unstable unstable \
+    && nix-channel --update
 
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553


### PR DESCRIPTION
This PR upgrade the channel to the latest stable version (19.03).
I also added the extra `nixpkgs-unstable` channel under the `unstable` namespace.