### PR TITLE
volume: change base images to be able to mount /nix/store as volume

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
     - env: BASE_OS=debian
 
 script:
-  - docker build --pull -t fretlink/nix ${BASE_OS}/
+  - docker build --pull -t fretlink/nix -f ${BASE_OS}/Dockerfile .
   - docker run -it --rm fretlink/nix 'nix-channel --list'
   - docker run -it --rm fretlink/nix 'nix-env -iA nixpkgs.hello && test "$(hello)" = "Hello, world!"'

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -36,8 +36,17 @@ RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553
 # The same is hapenning with stack2nix
-RUN nix-env -iA nixpkgs.glibcLocales \
-    && echo "export LOCALE_ARCHIVE=$(nix-env --installed --no-name --out-path --query glibc-locales)/lib/locale/locale-archive" >> ${HOME}/.profile
+RUN nix-env -iA nixpkgs.glibcLocales
+
+# < Nix context as a volume
+# We want to be able to define /nix/store as a volume
+# We thus need to "save" the current nix context to be able
+# to restore it at startup time
+RUN cp -R /nix /home/nixuser/initial-nix
+VOLUME ["/nix"]
+# Create bash profile
+COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
+# />
 
 # Make sure to use "login" shell when running container
 ENTRYPOINT ["/usr/bin/env", "bash", "-l", "-c"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -36,8 +36,17 @@ RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553
 # The same is hapenning with stack2nix
-RUN nix-env -iA nixpkgs.glibcLocales \
-    && echo "export LOCALE_ARCHIVE=$(nix-env --installed --no-name --out-path --query glibc-locales)/lib/locale/locale-archive" >> ${HOME}/.profile
+RUN nix-env -iA nixpkgs.glibcLocales
+
+# < Nix context as a volume
+# We want to be able to define /nix/store as a volume
+# We thus need to "save" the current nix context to be able
+# to restore it at startup time
+RUN cp -R /nix /home/nixuser/initial-nix
+VOLUME ["/nix"]
+# Create bash profile
+COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
+# />
 
 # Make sure to use "login" shell when running container
 ENTRYPOINT ["/usr/bin/env", "bash", "-l", "-c"]

--- a/files/.profile
+++ b/files/.profile
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copy initial saved nix context if the /nix is empty
+[ ! "$(ls -A /nix)" ] && cp -R ~/initial-nix/* /nix/
+
+# Source nix environment
+nix_profile="/home/nixuser/.nix-profile/etc/profile.d/nix.sh"
+# shellcheck source=/home/nixuser/.nix-profile/etc/profile.d/nix.sh
+[ -e "${nix_profile}" ] && . "${nix_profile}"
+
+# Propagate UTF8
+# https://github.com/NixOS/nix/issues/599#issuecomment-153885553
+LOCALE_ARCHIVE="$(nix-env --installed --no-name --out-path --query glibc-locales)/lib/locale/locale-archive"
+export LOCALE_ARCHIVE


### PR DESCRIPTION
These changes will allow the nix store to be mounted as a volume and
still be able to launch a bash console with the correct nix
environment.