### PR TITLE
Use dedicated system path for nix

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,6 +19,7 @@ USER nixuser
 ENV USER=nixuser
 ENV HOME="/home/nixuser"
 ENV NIX_SYSTEM_PATH="/nix/var/nix/profiles/system"
+ENV NIX_PROFILE="$HOME/nix-envs"
 
 RUN cd && wget https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.xz \
     && tar xJf nix-*-x86_64-linux.tar.xz \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,16 +18,18 @@ RUN addgroup -g 30000 -S nixbld \
 USER nixuser
 ENV USER=nixuser
 ENV HOME="/home/nixuser"
+ENV NIX_SYSTEM_PATH="/nix/var/nix/profiles/system"
 
 RUN cd && wget https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.xz \
     && tar xJf nix-*-x86_64-linux.tar.xz \
-    && ~/nix-*-x86_64-linux/install \
+    && NIX_PROFILE="$NIX_SYSTEM_PATH" ~/nix-*-x86_64-linux/install \
     && rm -rf ~/nix-*-*
 
-ENV ENV="/home/nixuser/.nix-profile/etc/profile.d/nix.sh"
-RUN echo ". ${ENV}" >> ${HOME}/.profile
 # All subsequent "RUN" will use a login shell
 SHELL ["/usr/bin/env", "bash", "-l", "-c"]
+
+# Create bash profile
+COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
 
 RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
     && nix-channel --add https://nixos.org/channels/nixpkgs-unstable unstable \
@@ -36,13 +38,11 @@ RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553
 # The same is hapenning with stack2nix
-RUN nix-env -iA nixpkgs.glibcLocales
+RUN nix-env -p "$NIX_SYSTEM_PATH" -iA nixpkgs.glibcLocales
 
 # < Nix context as a volume
 # We want to be able to define /nix/store as a volume
 VOLUME ["/nix"]
-# Create bash profile
-COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
 # />
 
 # Make sure to use "login" shell when running container

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine
 
 ARG NIX_VERSION
-ENV NIX_VERSION ${NIX_VERSION:-2.3.4}
+ENV NIX_VERSION ${NIX_VERSION:-2.3.9}
 ARG LANG
 ENV LANG ${LANG:-"en_US.UTF-8"}
 
@@ -32,8 +32,7 @@ SHELL ["/usr/bin/env", "bash", "-l", "-c"]
 # Create bash profile
 COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
 
-RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
-    && nix-channel --add https://nixos.org/channels/nixpkgs-unstable unstable \
+RUN nix-channel --add https://nixos.org/channels/nixos-unstable nixpkgs \
     && nix-channel --update
 
 # Propagate UTF8

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -18,16 +18,18 @@ RUN addgroup --gid 30000 --system nixbld \
 USER nixuser
 ENV USER=nixuser
 ENV HOME="/home/nixuser"
+ENV NIX_SYSTEM_PATH="/nix/var/nix/profiles/system"
 
 RUN cd && wget https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.xz \
     && tar xJf nix-*-x86_64-linux.tar.xz \
-    && ~/nix-*-x86_64-linux/install \
+    && NIX_PROFILE="$NIX_SYSTEM_PATH" ~/nix-*-x86_64-linux/install \
     && rm -rf ~/nix-*-*
 
-ENV ENV="/home/nixuser/.nix-profile/etc/profile.d/nix.sh"
-RUN echo ". ${ENV}" >> ${HOME}/.profile
 # All subsequent "RUN" will use a login shell
 SHELL ["/usr/bin/env", "bash", "-l", "-c"]
+
+# Create bash profile
+COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
 
 RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
     && nix-channel --add https://nixos.org/channels/nixpkgs-unstable unstable \
@@ -36,13 +38,11 @@ RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553
 # The same is hapenning with stack2nix
-RUN nix-env -iA nixpkgs.glibcLocales
+RUN nix-env -p "$NIX_SYSTEM_PATH" -iA nixpkgs.glibcLocales
 
 # < Nix context as a volume
 # We want to be able to define /nix/store as a volume
 VOLUME ["/nix"]
-# Create bash profile
-COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
 # />
 
 # Make sure to use "login" shell when running container

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:stable-slim
 
 ARG NIX_VERSION
-ENV NIX_VERSION ${NIX_VERSION:-2.3.4}
+ENV NIX_VERSION ${NIX_VERSION:-2.3.9}
 ARG LANG
 ENV LANG ${LANG:-"en_US.UTF-8"}
 
@@ -32,8 +32,7 @@ SHELL ["/usr/bin/env", "bash", "-l", "-c"]
 # Create bash profile
 COPY --chown=nixuser:nixuser files/.profile ${HOME}/.profile
 
-RUN nix-channel --add https://nixos.org/channels/nixpkgs-19.09-darwin nixpkgs \
-    && nix-channel --add https://nixos.org/channels/nixpkgs-unstable unstable \
+RUN nix-channel --add https://nixos.org/channels/nixos-unstable nixpkgs \
     && nix-channel --update
 
 # Propagate UTF8

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -19,6 +19,7 @@ USER nixuser
 ENV USER=nixuser
 ENV HOME="/home/nixuser"
 ENV NIX_SYSTEM_PATH="/nix/var/nix/profiles/system"
+ENV NIX_PROFILE="$HOME/nix-envs"
 
 RUN cd && wget https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x86_64-linux.tar.xz \
     && tar xJf nix-*-x86_64-linux.tar.xz \

--- a/files/.profile
+++ b/files/.profile
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
 # Source nix environment
-nix_profile="/home/nixuser/.nix-profile/etc/profile.d/nix.sh"
-# shellcheck source=/home/nixuser/.nix-profile/etc/profile.d/nix.sh
+nix_profile="$NIX_SYSTEM_PATH/etc/profile.d/nix.sh"
+# shellcheck source=$NIX_SYSTEM_PATH/etc/profile.d/nix.sh
 [ -e "${nix_profile}" ] && . "${nix_profile}"
 
 # Propagate UTF8
 # https://github.com/NixOS/nix/issues/599#issuecomment-153885553
-LOCALE_ARCHIVE="$(nix-env --installed --no-name --out-path --query glibc-locales)/lib/locale/locale-archive"
+LOCALE_ARCHIVE="$NIX_SYSTEM_PATH/lib/locale/locale-archive"
 export LOCALE_ARCHIVE
+
+PATH="$PATH:$NIX_SYSTEM_PATH/bin"

--- a/files/.profile
+++ b/files/.profile
@@ -10,4 +10,4 @@ nix_profile="$NIX_SYSTEM_PATH/etc/profile.d/nix.sh"
 LOCALE_ARCHIVE="$NIX_SYSTEM_PATH/lib/locale/locale-archive"
 export LOCALE_ARCHIVE
 
-PATH="$PATH:$NIX_SYSTEM_PATH/bin"
+PATH="$NIX_PROFILE/bin:$PATH:$NIX_SYSTEM_PATH/bin"


### PR DESCRIPTION
This PR attempts to sanitize a bit the docker image related to nix. With the proposed change, every "critical" tool will end up in /nix/var/nix/profiles/system(/bin) . This includes the nix-foo tools and glibc (for UTF-8). It is then manually added to the PATH in the profile file.

This path can then be safely shared between concurrent containers, since it is defined at build time of the container.

The second commit might be a little more controversial: it will ditch out the use of /home/nixuser/.nix-profile (which is a symlink to /var/nix/profiles/per-user/nixuser/profile) and make nix-env use ~/nix-envs by default. This has the advantage of completely releasing us from the leak of /nix/var accross jobs. However, I remember that some commands hardcode /home/nixuser/.nix-profile and will need adjustement (makefile or toolbox IIRC).