### PR TITLE
Remove sandbox=false

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,8 +12,7 @@ RUN addgroup -g 30000 -S nixbld \
     && mkdir -m 0755 /nix && chown nixuser /nix \
     && apk add --no-cache bash xz \
     && rm -rf /var/cache/apk/* \
-    # sandboxing enabled by default since 2.2
-    && mkdir -p /etc/nix && echo 'sandbox = false' > /etc/nix/nix.conf
+    && mkdir -p /etc/nix && touch /etc/nix/nix.conf
 
 USER nixuser
 ENV USER=nixuser

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -12,8 +12,7 @@ RUN addgroup --gid 30000 --system nixbld \
     && mkdir -m 0755 /nix && chown nixuser /nix \
     && apt update && apt install -y wget xz-utils \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    # sandboxing enabled by default since 2.2
-    && mkdir -p /etc/nix && echo 'sandbox = false' > /etc/nix/nix.conf
+    && mkdir -p /etc/nix && touch /etc/nix/nix.conf
 
 USER nixuser
 ENV USER=nixuser


### PR DESCRIPTION
The sandbox was (probably) disabled due to the .stack/shell.nix files: it made use of buildStackProject, which requires to run outside of the sandbox for some reason ( https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/generic-stack-builder.nix#L25 ). Now that this file is not used anymore, we can reenable the sandbox.

It should help fix in particular this recent issue we’re facing in the CI: https://github.com/jfischoff/tmp-postgres/issues/251